### PR TITLE
Implement Dockerflow requirements for the mozphab (Phabricator) container

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,7 +14,6 @@ cd phabricator
 
 # Set the local repository and make sure it is readable by the web user.
 ./bin/config set repository.default-local-path "${REPOSITORY_LOCAL_PATH}"
-chown -R www-data:www-data $REPOSITORY_LOCAL_PATH
 
 ./bin/config set mysql.host ${MYSQL_HOST}
 ./bin/config set mysql.port ${MYSQL_PORT}

--- a/site.conf
+++ b/site.conf
@@ -1,6 +1,21 @@
 server {
   server_name phabricator.dev;
-  root        /var/www/html/phabricator/webroot;
+  root /app/phabricator/webroot;
+
+  location = /__version__ {
+    root /app;
+    default_type application/json;
+    try_files version.json =404;
+  }
+
+  location = /__lheartbeat__ {
+    default_type text/plain;
+    return 200 "Hello World!";
+  }
+
+  location = /__heartbeat__ {
+    rewrite ^.*$ /api/conduit.ping last;
+  }
 
   location / {
     index index.php;


### PR DESCRIPTION
Implemented the following Dockerflow requirements:
- Must have a JSON version object at /app/version.json.
- Respond to /__version__ with the contents of /app/version.json.
- Respond to /__heartbeat__ with a HTTP 200 or 5xx on error. This should check backing services like a database for connectivity.
- Respond to /__lbheartbeat__ with an HTTP 200. This is for load balancer checks and should not
  check backing services.

Questions:
- The mozphab container does not currently install nginx and we have been using a docker-compose.yml to bring up nginx in a separate container and proxy to the mozphab container.
Is that acceptable for our deployment or does mozphab need to have also server content via nginx and use the site.conf installed in /app? Do you have any examples of setups similar what we will be using that I can see how to properly handle that?

Thanks
dkl