### PR TITLE
minor adduser tweak

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -89,7 +89,7 @@ RUN { \
     } | tee /usr/local/etc/php/conf.d/phabricator.ini
 
 # add a non-privileged user for installing and running the application
-RUN addgroup -g 10001 app && adduser -D -u 10001 -G app -h /app app
+RUN addgroup -g 10001 app && adduser -D -u 10001 -G app -h /app -s /bin/sh app
 
 COPY . /app
 WORKDIR /app


### PR DESCRIPTION
  - explicitly set a shell; without this, the gecos field for shell is left blank and makes using su or gosu impossible.