### PR TITLE
Update mozphab version,json

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -114,4 +114,4 @@ RUN chmod +x /app/entrypoint.sh /app/wait-for-mysql.php \
     && chown -R app:app /app $REPOSITORY_LOCAL_PATH
 
 USER app
-VOLUME ["$REPOSITORY_LOCAL_PATH", "/app"]
+VOLUME ["$REPOSITORY_LOCAL_PATH"]

--- a/circle.yml
+++ b/circle.yml
@@ -19,9 +19,8 @@ dependencies:
 
 compile:
   override:
-    # create version.json
-    - invoke version >> circle.json
-    - cp circle.json $CIRCLE_ARTIFACTS
+    - invoke version >> mozphab.json
+    - cp mozphab.json $CIRCLE_ARTIFACTS
 
     # build the image
     - invoke build

--- a/merge_versions.py
+++ b/merge_versions.py
@@ -4,7 +4,7 @@ import os
 import sys
 
 try:
-    with open('/app/circle.json', 'r') as f:
+    with open('/app/mozphab.json', 'r') as f:
         circle_data = json.load(f)
 except IOError:
     circle_data = {}
@@ -20,7 +20,7 @@ app_data = {
 }
 app_data.update(circle_data)
 try:
-    with open('/app/version.json', 'w') as f:
+    with open('/app/mozphab.json', 'w') as f:
         json.dump(app_data, f)
 except IOError:
     sys.exit()


### PR DESCRIPTION
  - usually this container will not be deployed as a standalone instance thus
the version.json is not needed for Dockerflow purposes. However, the version
information *is* important for builds that use this container as a
source. Make the version information available in the mozphab.json file
instead of version.json so later containers can create+update
version.json in their build.

we export /app at the phabext build, so don't export it here