### PR TITLE
Ensure we have an updated static resources map during start

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -64,6 +64,10 @@ case "$ARG" in
       ./bin/config set pygments.enabled true
       ./bin/config set phabricator.timezone UTC
 
+      # Ensure that we have an updated static resources map
+      # Required so extension resources are accounted for and available
+      ./bin/celerity map
+
       # Start phd and php-fpm running in the foreground
       ./bin/phd start && /usr/local/sbin/php-fpm -F
       ;;


### PR DESCRIPTION
Goes with: https://github.com/mozilla-services/phabricator-extensions/pull/21/files

Phabricator extensions we write may require their own JavaScript and CSS files.  Per https://secure.phabricator.com/book/phabcontrib/article/adding_new_css_and_js/ , for static asset names to be available by reference, we must generate a new asset map.  

The directive in this PR ensures we have a fresh map when we start/deploy.