### PR TITLE
Update dependencies and add command to build Phabricator docs on container start

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,9 +29,11 @@ ENV REPOSITORY_LOCAL_PATH /repo
 RUN apk --no-cache --update add \
     curl \
     freetype \
+    g++ \
     libjpeg-turbo \
     libmcrypt \
     libpng \
+    make \
     mercurial \
     mariadb-client \
     mariadb-client-libs \
@@ -104,7 +106,8 @@ RUN curl -fsSL https://github.com/phacility/phabricator/archive/${PHABRICATOR_GI
     && mv phabricator-${PHABRICATOR_GIT_SHA} phabricator \
     && mv arcanist-${ARCANIST_GIT_SHA} arcanist \
     && mv libphutil-${LIBPHUTIL_GIT_SHA} libphutil \
-    && rm phabricator.tar.gz arcanist.tar.gz libphutil.tar.gz
+    && rm phabricator.tar.gz arcanist.tar.gz libphutil.tar.gz \
+    && ./libphutil/scripts/build_xhpast.php
 
 # Create version.json
 RUN /app/merge_versions.py

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -68,6 +68,9 @@ case "$ARG" in
       # Required so extension resources are accounted for and available
       ./bin/celerity map
 
+      # Build diviner docs
+      ./bin/diviner generate
+
       # Start phd and php-fpm running in the foreground
       ./bin/phd start && /usr/local/sbin/php-fpm -F
       ;;


### PR DESCRIPTION
- Add make and g++ package dependencies needed my build_xhpast.php
- Build the docs in entrypoint.sh on container startup. Only slow the
  first time
- Docs are in DB so as long as starting a container pointed at the previous DB, then 
  future builds should happen quickly.