### PR TITLE
use version.json for docker container, not mozphab.json

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -19,8 +19,8 @@ dependencies:
 
 compile:
   override:
-    - invoke version >> mozphab.json
-    - cp mozphab.json $CIRCLE_ARTIFACTS
+    - invoke version >> version.json
+    - cp version.json $CIRCLE_ARTIFACTS
 
     # build the image
     - invoke build

--- a/merge_versions.py
+++ b/merge_versions.py
@@ -4,8 +4,9 @@ import os
 import sys
 
 try:
-    with open('/app/mozphab.json', 'r') as f:
+    with open('/app/version.json', 'r') as f:
         circle_data = json.load(f)
+        f.close()
 except IOError:
     circle_data = {}
 
@@ -20,7 +21,7 @@ app_data = {
 }
 app_data.update(circle_data)
 try:
-    with open('/app/mozphab.json', 'w') as f:
+    with open('/app/version.json', 'w') as f:
         json.dump(app_data, f)
 except IOError:
     sys.exit()


### PR DESCRIPTION
In some cases, the base container may be used elsewhere; A missing version.json breaks our deployment infra and makes this container useless for further use.