### PR TITLE
Update Phabricator SHA to latest stable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,9 @@ ENTRYPOINT ["/app/entrypoint.sh"]
 CMD ["start"]
 
 # Git commit SHAs for the build artifact we want to grab.
-# Default is SHAs for 2017/11/07 Promote 2017 Week 14 (sic, Week 44)
+# Default is SHAs for 2017/11/14 (stable) Restore "Summary" and "Test Plan" to initial mail for non-dr…
 # From https://github.com/phacility/phabricator/commits/stable
-ENV PHABRICATOR_GIT_SHA 180f3754f092d22a0d39d9c86725e28020da8210
+ENV PHABRICATOR_GIT_SHA c098aec66931720b7de19b8ef628bb6d735c3fab
 
 # From https://github.com/phacility/arcanist/commits/stable
 # Promote 2017 Week 14 (sic, Week 44)


### PR DESCRIPTION
Updated to latest sha's here https://secure.phabricator.com/w/changelog/2017.45/, only the phab sha has changed since the others are still current.