### PR TITLE
set auth.require-approval to false in dev_start

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -79,7 +79,7 @@ case "$ARG" in
   "dev_start")
       set +e
       check_database
-      ./bin/config set auth.require-approval true
+      ./bin/config set auth.require-approval false
       start
       ;;
   "start")

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -79,6 +79,7 @@ case "$ARG" in
   "dev_start")
       set +e
       check_database
+      ./bin/config set auth.require-approval true
       start
       ;;
   "start")


### PR DESCRIPTION
I think auth approvals definitely should not be required in a dev environment.

compared to:
```
12:15 <imadueme> [...] on pahbricator add a "?admin" to the end of whatever URL you are on. A
 "phab" login page will show up where you can enter admin/admin. Then click on a user's name, 
click on the "People" breadcrumb, click on the approval queue
```