### PR TITLE
turn off exitfailure when running dev_start

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -77,6 +77,7 @@ check_database() {
 
 case "$ARG" in
   "dev_start")
+      set +e
       check_database
       start
       ;;


### PR DESCRIPTION
This wasn't obvious because in bash, set -e is a global.
But for the /bin/sh of this image, it is scoped to the function.

the snippet below will print "hello world" on two lines in bash, but only "hello" in
the busybox sh.

```bash

set -e

foo() {
    set +e
    false
    echo "hello"
    return 1
}

foo
echo "world"
```