### PR TITLE
Tweaks needed for GCP

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -98,6 +98,7 @@ RUN addgroup -g 10001 app && adduser -D -u 10001 -G app -h /app -s /bin/sh app
 
 COPY . /app
 WORKDIR /app
+RUN mkdir tmpfiles
 
 # Install Phabricator code
 RUN curl -fsSL https://github.com/phacility/phabricator/archive/${PHABRICATOR_GIT_SHA}.tar.gz -o phabricator.tar.gz \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -53,6 +53,10 @@ start() {
     test -n "${BUGZILLA_AUTOMATION_API_KEY}" \
         && ./bin/config set bugzilla.automation_api_key "${BUGZILLA_AUTOMATION_API_KEY}"
 
+    if test -e /app/tmpfiles/local.json; then
+      cp /app/tmpfiles/local.json /app/phabricator/conf/local/local.json
+    fi
+
     # Set recommended runtime configuration values to silence setup warnings.
     ./bin/config set storage.mysql-engine.max-size 8388608
     ./bin/config set pygments.enabled true


### PR DESCRIPTION
Brief explanation: GCP maps config files into the containers in a
read-only mode via configMaps. For whatever reason, phabricator really
hates the idea of local.json being read-only and will complain loudly.

To reduce background noise, I'd like to map the local.json into a
holding directory and then copy it into the correct location prior to
application startup. This way, the file should A) Exist where it needs
to and B) Be writable by the phabricator user.

These changes should allow this with a minimum of fuss. Feel free to
follow up with any questions.