### PR TITLE
 Bug 1606762 - xdebug support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,7 +63,6 @@ RUN apk --no-cache add --virtual build-dependencies \
         iconv \
         mbstring \
         mysqli \
-        opcache \
         pcntl \
     && pecl install apcu-5.1.17 \
     && docker-php-ext-enable apcu \
@@ -74,17 +73,6 @@ RUN apk --no-cache add --virtual build-dependencies \
     && apk del build-dependencies
 
 RUN wget -O /usr/local/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.1/dumb-init_1.2.1_amd64 && if test -f /usr/local/bin/dumb-init; then chmod 755 /usr/local/bin/dumb-init; fi
-
-# Install opcache recommended settings from
-# https://secure.php.net/manual/en/opcache.installation.php
-RUN { \
-        echo 'opcache.memory_consumption=128'; \
-        echo 'opcache.interned_strings_buffer=8'; \
-        echo 'opcache.max_accelerated_files=4000'; \
-        echo 'opcache.fast_shutdown=1'; \
-        echo 'opcache.enable_cli=1'; \
-        echo 'opcache.validate_timestamps=0'; \
-    } | tee /usr/local/etc/php/conf.d/opcache.ini
 
 # The container does not log errors by default, so turn them on
 RUN { \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -79,9 +79,12 @@ start() {
         /usr/local/sbin/php-fpm -F
         ;;
       "dev")
-        # TODO rather than installing "opcache" in our base phabricator image, then reverting it for dev,
-        # we should have a production and dev image (and only install "opcache" in the production one)
-        ./bin/phd start && exec /usr/local/sbin/php-fpm -d opcache.enable=0 -F
+        # the host is always octet 1 on the current virtual network
+        # E.g.: if this container is running on 172.27.0.16, the host is 172.27.0.1
+        host_address=$(hostname -i | awk '{split($1,a,".");print a[1] "." a[2] "." a[3] ".1"}')
+        export XDEBUG_CONFIG="remote_host=$host_address"
+        export PHP_IDE_CONFIG="serverName=phabricator.test"
+        ./bin/phd start && exec /usr/local/sbin/php-fpm -F
         ;;
       *)
         ./bin/phd start && exec /usr/local/sbin/php-fpm -F


### PR DESCRIPTION
Moves opache-installation logic into the now-multi-stage-build docker image in phabricator-extensions.
Automatically determines docker host IP and points xdebug requests in that direction.

This depends on #104